### PR TITLE
making touchpoints ordered

### DIFF
--- a/models/localMacros.yaml
+++ b/models/localMacros.yaml
@@ -8,3 +8,8 @@ macros:
       - column
       - number_of_days
     value: "{% if !(end_time|isnil) %} datediff(day, date({{column}}), date('{{end_time.Format(\"2006-01-02 15:04:05\")}}')) <={{number_of_days}} {% else %} datediff(day, date({{column}}), GETDATE()) <= {{number_of_days}} {% endif %}"
+  - name: macro_listagg
+    inputs:
+      - column
+      - timestamp
+    value: "{% if warehouse.DatabaseType() == \"bigquery\" %} STRING_AGG({{column}}, ',' ORDER BY {{timestamp}} ASC) {% else %} LISTAGG({{column}}, ',') WITHIN group (order by {{timestamp}} ASC) {% endif %}"

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -73,30 +73,46 @@ models:
             from: inputs/rsOrderCompleted
             description: Whether a customer has ever made a payment
         - entity_var:
+            name: first_payment_date
+            select: min(timestamp)
+            from: inputs/rsOrderCompleted
+            where: REVENUE>0
+        - entity_var:
             name: campaign_sources
-            select: array_agg( context_campaign_source )
+            select: "{{macro_listagg('context_campaign_source', 'original_timestamp')}}"
             from: inputs/rsIdentifies
+            where: context_campaign_source IS NOT NULL and timestamp <= {{user.Var("first_payment_date")}}
+            dependencies:
+              - first_payment_date
         - entity_var:
             name: campaigns_list
             from: models/pages_orderby_table
-            select: array_agg( context_campaign_name)
+            select: "{{macro_listagg('context_campaign_name', 'original_timestamp')}}"
+            where: context_campaign_name IS NOT NULL and timestamp <= {{user.Var("first_payment_date")}}
             description: list of all campaigns from which a user has visited the app, sorted in chronological order, from oldest to newest
+            dependencies:
+              - first_payment_date
         - entity_var:
             name: mediums_list
             from: models/pages_orderby_table
-            select: array_agg( context_campaign_medium)
+            select: "{{macro_listagg('context_campaign_medium', 'original_timestamp')}}"
+            where: context_campaign_medium IS NOT NULL and timestamp <= {{user.Var("first_payment_date")}}
             description: list of all mediums from which a user has visited the app, sorted in chronological order, from oldest to newest
+            dependencies:
+              - first_payment_date
         - entity_var:
             name: sources_list
             from: models/pages_orderby_table
-            select: array_agg( context_campaign_source)
+            select: "{{macro_listagg('context_campaign_source', 'original_timestamp')}}"
+            where: context_campaign_source IS NOT NULL and timestamp <= {{user.Var("first_payment_date")}}
             description: list of all sources from which a user has visited the app, sorted in chronological order, from oldest to newest
             dependencies:
-              - session_start_time
+              - first_payment_date
       features:
         - days_since_first_seen
         - gross_amt_spent_overall
         - is_payer
+        - first_payment_date
         - campaign_sources
         - campaigns_list
         - mediums_list


### PR DESCRIPTION
## Description of the change

> Touchpoints information was not in sorted order as it was previously using `array_agg()` which if not used with `order by` has no surety of ordered results.
> Now, it'll generate the touchpoint vars as string separated by commas.
> [Ticket](https://linear.app/rudderstack/issue/PRML-487/attribution-model-touch-points-ordering-bug)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
